### PR TITLE
Issue #30: Set KOHA_NO_TABLE_LOCKS=1 to avoid LOCK

### DIFF
--- a/files/run.sh
+++ b/files/run.sh
@@ -62,6 +62,7 @@ else
     rm -rf cover_db
     koha-shell kohadev -p -c "JUNIT_OUTPUT_FILE=junit_main.xml \
                               PERL5OPT=-MDevel::Cover \
+                              KOHA_NO_TABLE_LOCKS=1 \
                               KOHA_INTRANET_URL=${KOHA_INTRANET_URL} \
                               KOHA_OPAC_URL=${KOHA_OPAC_URL} \
                               KOHA_USER=${KOHA_USER} \


### PR DESCRIPTION
KOHA_NO_TABLE_LOCKS needs to be set, to avoid LOCK (rollback will fail)
From Koha code:
my $do_not_lock = ( exists $ENV{} && $ENV{} =~ m|prove| ) ||
$ENV{KOHA_NO_TABLE_LOCKS};

$ENV{_} equals "koha-shell", not the expected "prove"