### PR TITLE
Issue #47: Mount /tmp and /cover_db as tmpfs volumes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,9 @@ services:
             - ALL
         volumes:
             - ${SYNC_REPO}:/kohadevbox/koha
+        tmpfs:
+            - /cover_db
+            - /tmp
         environment:
             KOHA_INSTANCE: kohadev
             KOHA_DB_PASSWORD: password

--- a/files/run.sh
+++ b/files/run.sh
@@ -64,9 +64,9 @@ if [ ${DEBUG} ]; then
     bash
 else
     cd ${BUILD_DIR}/koha
-    rm -rf cover_db
+    rm -rf /cover_db/*
     koha-shell kohadev -p -c "JUNIT_OUTPUT_FILE=junit_main.xml \
-                              PERL5OPT=-MDevel::Cover \
+                              PERL5OPT=-MDevel::Cover=-db,/cover_db \
                               KOHA_NO_TABLE_LOCKS=1 \
                               KOHA_INTRANET_URL=${KOHA_INTRANET_URL} \
                               KOHA_OPAC_URL=${KOHA_OPAC_URL} \


### PR DESCRIPTION
We have performance issues, it would be good to see if mounting /tmp and
/cover_db as tmpfs volumes will not improve them a bit.